### PR TITLE
Refine logic around server start

### DIFF
--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : AppCompatActivity() {
         /** One-time startup state machine (survives Activity recreation via static). */
         enum class Startup {
             NOT_STARTED,           // Fresh launch, nothing done yet
-            PREPARING,             // Asset copy / IO in progress
+            DELETING_LOGS_COPYING_ASSETS,  // Asset copy / IO in progress
             AWAITING_RESUME_TO_REQUEST_PERMISSION,  // Need to request permission; deferred until Activity is RESUMED
             PERMISSION_REQUESTED,  // System dialog is visible (guards duplicate requestPermissions calls)
             RUNNING                // Node.js process has been started
@@ -124,7 +124,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         if (startupState == Startup.NOT_STARTED) {
-            startupState = Startup.PREPARING
+            startupState = Startup.DELETING_LOGS_COPYING_ASSETS
             Log.d(TAG, "First run: starting asset copy and Node setup")
             // Use lifecycleScope to perform IO work and then switch to UI for permission/service start
             lifecycleScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -245,9 +245,8 @@ class MainActivity : AppCompatActivity() {
         if (startupState == Startup.RUNNING) return
         startupState = Startup.RUNNING
         Log.d(TAG, "Starting Node.js process")
-        val dir = nodeDir
         Thread {
-            startNodeWithArguments(arrayOf("node", "$dir/main.js"))
+            startNodeWithArguments(arrayOf("node", "$nodeDir/main.js"))
         }.start()
     }
 

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -166,8 +166,8 @@ class MainActivity : AppCompatActivity() {
             logCleared = true
             logViewModel.startPolling()
 
-            // If Node hasn't actually started yet, continue the startup flow
-            if (startupState != Startup.RUNNING && startupState != Startup.PERMISSION_REQUESTED && startupState != Startup.PREPARING) {
+            // If we were waiting for the permission dialog when the Activity was recreated, retry
+            if (startupState == Startup.AWAITING_PERMISSION) {
                 requestPermissionOrStart()
             }
         }

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -240,7 +240,11 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         if (permissionRequest == PermissionRequest.AWAITING_RESUME) {
-            requestPermissionIfNeeded()
+            // We're guaranteed to be RESUMED here, so request directly
+            // (don't go through requestPermissionIfNeeded which re-checks lifecycle state)
+            permissionRequest = PermissionRequest.IN_FLIGHT
+            Log.d(TAG, "Requesting notification permission (from onResume)")
+            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQ_POST_NOTIFICATIONS)
         }
     }
 

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -95,13 +95,13 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this@MainActivity, HowToUseActivity::class.java))
         }
 
-    // Initialize log UI and ViewModel once in onCreate so state survives config changes
-    val scrollView = findViewById<android.widget.ScrollView>(R.id.scrollView)
-    val rvLogs = findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.rvLogs)
-    val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
-    rvLogs.layoutManager = layoutManager
-    val logAdapterRv = LogAdapter()
-    rvLogs.adapter = logAdapterRv
+        // Initialize log UI and ViewModel once in onCreate so state survives config changes
+        val scrollView = findViewById<android.widget.ScrollView>(R.id.scrollView)
+        val rvLogs = findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.rvLogs)
+        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
+        rvLogs.layoutManager = layoutManager
+        val logAdapterRv = LogAdapter()
+        rvLogs.adapter = logAdapterRv
         logViewModel = androidx.lifecycle.ViewModelProvider(this, androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.getInstance(application)).get(LogViewModel::class.java)
         logViewModel.lines.observe(this) { newLines ->
             // Check if ScrollView is at bottom (user is viewing latest logs)

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
         enum class Startup {
             NOT_STARTED,           // Fresh launch, nothing done yet
             PREPARING,             // Asset copy / IO in progress
-            AWAITING_PERMISSION,   // Waiting to show or showing the notification permission dialog
+            AWAITING_RESUME_TO_REQUEST_PERMISSION,  // Need to request permission; deferred until Activity is RESUMED
             PERMISSION_REQUESTED,  // System dialog is visible (guards duplicate requestPermissions calls)
             RUNNING                // Node.js process has been started
         }
@@ -167,7 +167,7 @@ class MainActivity : AppCompatActivity() {
             logViewModel.startPolling()
 
             // If we were waiting for the permission dialog when the Activity was recreated, retry
-            if (startupState == Startup.AWAITING_PERMISSION) {
+            if (startupState == Startup.AWAITING_RESUME_TO_REQUEST_PERMISSION) {
                 requestPermissionOrStart()
             }
         }
@@ -203,7 +203,7 @@ class MainActivity : AppCompatActivity() {
                 startServiceAndNode()
             } else if (startupState != Startup.PERMISSION_REQUESTED) {
                 Log.d(TAG, "Requesting notification permission")
-                startupState = Startup.AWAITING_PERMISSION
+                startupState = Startup.AWAITING_RESUME_TO_REQUEST_PERMISSION
                 if (lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.RESUMED)) {
                     startupState = Startup.PERMISSION_REQUESTED
                     ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQ_POST_NOTIFICATIONS)
@@ -216,7 +216,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        if (startupState == Startup.AWAITING_PERMISSION) {
+        if (startupState == Startup.AWAITING_RESUME_TO_REQUEST_PERMISSION) {
             requestPermissionOrStart()
         }
     }

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -217,9 +217,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         if (startupState == Startup.AWAITING_PERMISSION) {
-            startupState = Startup.PERMISSION_REQUESTED
-            Log.d(TAG, "onResume: requesting deferred notification permission")
-            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQ_POST_NOTIFICATIONS)
+            requestPermissionOrStart()
         }
     }
 

--- a/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
+++ b/app/src/main/java/com/dimadesu/mediasrvr/MainActivity.kt
@@ -206,6 +206,8 @@ class MainActivity : AppCompatActivity() {
                 Log.d(TAG, "Notification permission already granted")
                 permissionResult = true
                 tryStart()
+            // Guard: requestPermissions() can recreate the Activity; without this check
+            // the new Activity would re-call requestPermissions() in an infinite loop.
             } else if (permissionRequest != PermissionRequest.IN_FLIGHT) {
                 Log.d(TAG, "Requesting notification permission")
                 if (lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.RESUMED)) {


### PR DESCRIPTION
- 2 things hold server from starting:
  - logs deletion + copying of assets
  - notification permission checks
- Run those in parallel
- Guard for double starting server
- Double/triple check logic around lifecycle events
  - Try to make it more readable / easier to maintain