### PR TITLE
Work around 16 KB page-size crash for prebuilt libnode.so

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,12 +70,14 @@ android {
         }
     }
 
-    // For AAB (Play Store): uncompressed libs for 16 KB page alignment + mmap
-    // For APK (GitHub releases): compressed libs for smaller download size
-    def isApkBuild = gradle.startParameter.taskNames.any { it.toLowerCase().contains("assemble") }
+    // For AAB (Play Store): keep uncompressed libs so bundle/APK generation can
+    // preserve direct-from-APK loading.
+    // For direct APK installs (assemble/install), use legacy packaging so
+    // the device extracts the already 16 KB-aligned ELF to the app lib dir.
+    def isBundleBuild = gradle.startParameter.taskNames.any { it.toLowerCase().contains("bundle") }
     packagingOptions {
         jniLibs {
-            useLegacyPackaging = isApkBuild
+            useLegacyPackaging = !isBundleBuild
         }
     }
     

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:pageSizeCompat="enabled"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"


### PR DESCRIPTION
The bundled libnode.so claims 16 KB alignment (p_align=0x4000) in its ELF headers, but the actual LOAD segment layout only has 4 KB gaps. Android's linker on 16 KB page-size devices detects this and refuses to load it:

  "libnode.so" program alignment (4096) cannot be smaller than
  system page size (16384)

Two workarounds are needed for direct APK installs:

1. useLegacyPackaging = true (for non-bundle builds) Extracts the .so to disk at install time instead of loading it directly from the APK via mmap, which would fail on misaligned segments.

2. android:pageSizeCompat="enabled" Tells the OS to use a compatibility shim that remaps the 4 KB- aligned segments into 16 KB-aligned memory at load time.

Bundle (AAB) builds keep useLegacyPackaging = false because Google Play re-packages the AAB into split APKs and handles alignment itself.